### PR TITLE
Allow for easier manual reporting

### DIFF
--- a/Sources/Bugsnag/Bugsnag.swift
+++ b/Sources/Bugsnag/Bugsnag.swift
@@ -33,12 +33,12 @@ struct BugsnagEvent: Encodable {
         breadcrumbs: [BugsnagBreadcrumb],
         error: Error,
         httpRequest: HTTPRequest? = nil,
+        keyFilters: [String],
         metadata: [String: CustomDebugStringConvertible],
         payloadVersion: String,
         severity: Severity,
         stacktrace: BugsnagStacktrace,
-        userId: CustomStringConvertible?,
-        keyFilters: [String]
+        userId: CustomStringConvertible?
     ) {
         self.app = app
         self.breadcrumbs = breadcrumbs
@@ -98,9 +98,7 @@ struct BugsnagRequest: Encodable {
     static private func filter(_ body: HTTPBody, using filters: [String]) -> String? {
         guard
             let data = body.data,
-            let unwrap = try? JSONSerialization.jsonObject(
-                with: data, options: []
-            ) as? [String: Any],
+            let unwrap = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let jsonObject = unwrap
         else {
             return body.data.flatMap { String(data: $0, encoding: .utf8) }

--- a/Sources/Bugsnag/Bugsnag.swift
+++ b/Sources/Bugsnag/Bugsnag.swift
@@ -23,7 +23,7 @@ struct BugsnagEvent: Encodable {
     let exceptions: [BugsnagException]
     let metaData: BugsnagMetaData
     let payloadVersion: String
-    let request: BugsnagRequest
+    let request: BugsnagRequest?
     let severity: String
     let unhandled = true
     let user: BugsnagUser?
@@ -32,12 +32,13 @@ struct BugsnagEvent: Encodable {
         app: BugsnagApp,
         breadcrumbs: [BugsnagBreadcrumb],
         error: Error,
-        httpRequest: HTTPRequest,
+        httpRequest: HTTPRequest? = nil,
         metadata: [String: CustomDebugStringConvertible],
         payloadVersion: String,
         severity: Severity,
         stacktrace: BugsnagStacktrace,
-        userId: CustomStringConvertible?
+        userId: CustomStringConvertible?,
+        keyFilters: [String]
     ) {
         self.app = app
         self.breadcrumbs = breadcrumbs
@@ -49,7 +50,7 @@ struct BugsnagEvent: Encodable {
             ].merging(metadata.mapValues { $0.debugDescription }) { a, b in b }
         )
         self.payloadVersion = payloadVersion
-        self.request = BugsnagRequest(httpRequest: httpRequest)
+        self.request = httpRequest.map { BugsnagRequest(httpRequest: $0, keyFilters: keyFilters) }
         self.severity = severity.value
         self.user = userId.map { BugsnagUser(id: $0.description) }
     }
@@ -85,13 +86,29 @@ struct BugsnagRequest: Encodable {
     let referer: String
     let url: String
 
-    init(httpRequest: HTTPRequest) {
-        self.body = httpRequest.body.data.flatMap { String(data: $0, encoding: .utf8) }
+    init(httpRequest: HTTPRequest, keyFilters: [String]) {
+        self.body = BugsnagRequest.filter(httpRequest.body, using: keyFilters)
         self.clientIp = httpRequest.remotePeer.hostname
         self.headers = Dictionary(httpRequest.headers.map { $0 }) { first, second in second }
         self.httpMethod = httpRequest.method.string
         self.referer = httpRequest.remotePeer.description
         self.url = httpRequest.urlString
+    }
+
+    static private func filter(_ body: HTTPBody, using filters: [String]) -> String? {
+        guard
+            let data = body.data,
+            let unwrap = try? JSONSerialization.jsonObject(
+                with: data, options: []
+            ) as? [String: Any],
+            let jsonObject = unwrap
+        else {
+            return body.data.flatMap { String(data: $0, encoding: .utf8) }
+        }
+
+        let filtered = jsonObject.filter { !filters.contains($0.key) }
+        let json = try? JSONSerialization.data(withJSONObject: filtered, options: [.prettyPrinted])
+        return json.flatMap { String(data: $0, encoding: .utf8) }
     }
 }
 

--- a/Sources/Bugsnag/BugsnagConfig.swift
+++ b/Sources/Bugsnag/BugsnagConfig.swift
@@ -1,17 +1,20 @@
 public struct BugsnagConfig {
     let apiKey: String
     let releaseStage: String
+    let keyFilters: [String]
     let shouldReport: Bool
     let debug: Bool
 
     public init(
         apiKey: String,
         releaseStage: String,
+        keyFilters: [String] = [],
         shouldReport: Bool = true,
         debug: Bool = false
     ) {
         self.apiKey = apiKey
         self.releaseStage = releaseStage
+        self.keyFilters = keyFilters
         self.shouldReport = shouldReport
         self.debug = debug
     }

--- a/Sources/Bugsnag/BugsnagReporter.swift
+++ b/Sources/Bugsnag/BugsnagReporter.swift
@@ -59,12 +59,12 @@ extension BugsnagReporter: ErrorReporter {
             breadcrumbs: breadcrumbs,
             error: error,
             httpRequest: req?.http,
+            keyFilters: config.keyFilters,
             metadata: metadata,
             payloadVersion: payloadVersion,
             severity: severity,
             stacktrace: stacktrace,
-            userId: userId,
-            keyFilters: config.keyFilters
+            userId: userId
         )
 
         let payload = BugsnagPayload(

--- a/Sources/Bugsnag/BugsnagReporter.swift
+++ b/Sources/Bugsnag/BugsnagReporter.swift
@@ -43,14 +43,15 @@ public struct BugsnagReporter: Service {
 extension BugsnagReporter: ErrorReporter {
     private func buildBody(
         _ container: Container,
-        req: Request?,
         error: Error,
         severity: Severity,
         userId: CustomStringConvertible?,
         metadata: [String: CustomDebugStringConvertible],
         stacktrace: BugsnagStacktrace
     ) throws -> Data {
-        let breadcrumbs: [BugsnagBreadcrumb] = (try? container
+        let req = container as? Request
+        let breadcrumbsContainer = req?.privateContainer ?? container
+        let breadcrumbs: [BugsnagBreadcrumb] = (try? breadcrumbsContainer
             .make(BreadcrumbContainer.self))?
             .breadcrumbs ?? []
 
@@ -95,7 +96,6 @@ extension BugsnagReporter: ErrorReporter {
         return Future.flatMap(on: container) {
             let body = try self.buildBody(
                 container,
-                req: container as? Request,
                 error: error,
                 severity: severity,
                 userId: userId,

--- a/Sources/Bugsnag/ErrorReporter.swift
+++ b/Sources/Bugsnag/ErrorReporter.swift
@@ -10,7 +10,7 @@ public protocol ErrorReporter {
         function: String,
         line: Int,
         column: Int,
-        on req: Request
+        on container: Container
     ) -> Future<Void>
 }
 
@@ -20,7 +20,7 @@ extension ErrorReporter {
         severity: Severity = .error,
         userId: CustomStringConvertible? = nil,
         metadata: [String: CustomDebugStringConvertible] = [:],
-        on req: Request,
+        on container: Container,
         file: String = #file,
         function: String = #function,
         line: Int = #line,
@@ -35,7 +35,7 @@ extension ErrorReporter {
             function: function,
             line: line,
             column: column,
-            on: req
+            on: container
         )
     }
 

--- a/Tests/BugsnagTests/BugsnagTests.swift
+++ b/Tests/BugsnagTests/BugsnagTests.swift
@@ -33,7 +33,7 @@ private class TestErrorReporter: ErrorReporter {
         function: String,
         line: Int,
         column: Int,
-        req: Request
+        container: Container
     )?
     func report(
         _ error: Error,
@@ -44,7 +44,7 @@ private class TestErrorReporter: ErrorReporter {
         function: String,
         line: Int,
         column: Int,
-        on req: Request
+        on container: Container
     ) -> Future<Void> {
         capturedReportParameters = (
             error,
@@ -55,9 +55,9 @@ private class TestErrorReporter: ErrorReporter {
             function,
             line,
             column,
-            req
+            container
         )
-        return req.future()
+        return container.future()
     }
 }
 
@@ -108,14 +108,14 @@ final class BugsnagTests: XCTestCase {
             host: String,
             headers: HTTPHeaders,
             body: Data,
-            request: Request
+            container: Container
         )?
 
         let reporter = BugsnagReporter(
             config: .init(apiKey: "apiKey", releaseStage: "test"),
-            sendReport: { host, headers, data, request in
-                capturedSendReportParameters = (host, headers, data, request)
-                return request.future(HTTPResponse(status: .ok))
+            sendReport: { host, headers, data, container in
+                capturedSendReportParameters = (host, headers, data, container)
+                return container.future(HTTPResponse(status: .ok))
         })
         let application = try Application.test()
         let request = Request(using: application)


### PR DESCRIPTION
This aims to solve/improve two things:
- Allow for "manual reporting" e.g. in a command where you don't have a request
- Enable key filtering so we don't end up having sensitive information in Bugsnag