### PR TITLE
Add optional version in reports

### DIFF
--- a/Sources/Bugsnag/Bugsnag.swift
+++ b/Sources/Bugsnag/Bugsnag.swift
@@ -151,6 +151,7 @@ struct BugsnagUser: Encodable {
 
 struct BugsnagApp: Encodable {
     let releaseStage: String
+    let version: String?
 }
 
 struct BugsnagMetaData: Encodable {

--- a/Sources/Bugsnag/BugsnagConfig.swift
+++ b/Sources/Bugsnag/BugsnagConfig.swift
@@ -1,6 +1,8 @@
 public struct BugsnagConfig {
     let apiKey: String
     let releaseStage: String
+    /// A version identifier, (eg. a git hash)
+    let version: String?
     let keyFilters: [String]
     let shouldReport: Bool
     let debug: Bool
@@ -8,12 +10,14 @@ public struct BugsnagConfig {
     public init(
         apiKey: String,
         releaseStage: String,
+        version: String? = nil,
         keyFilters: [String] = [],
         shouldReport: Bool = true,
         debug: Bool = false
     ) {
         self.apiKey = apiKey
         self.releaseStage = releaseStage
+        self.version = version
         self.keyFilters = keyFilters
         self.shouldReport = shouldReport
         self.debug = debug

--- a/Sources/Bugsnag/BugsnagReporter.swift
+++ b/Sources/Bugsnag/BugsnagReporter.swift
@@ -30,7 +30,8 @@ public struct BugsnagReporter: Service {
         }
 
         app = BugsnagApp(
-            releaseStage: config.releaseStage
+            releaseStage: config.releaseStage,
+            version: config.version
         )
         headers = .init([
             ("Content-Type", "application/json"),


### PR DESCRIPTION
This can be used to distinguish releases from each other. One could use git-hash if no version scheme is used.