### PR TITLE
Fix variable name in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Update `Sources/App/configure.swift`
 ```swift
 public func configure(
     _ config: inout Config,
-    _ env: inout Environment,
+    _ environment: inout Environment,
     _ services: inout Services
 ) throws {
     ...


### PR DESCRIPTION
Rename env to environment in the `configure` function signature so it matches how it is used inside the function.

relates to #63 