### PR TITLE
Filter out sensitive data from the HTTP headers

### DIFF
--- a/Sources/Bugsnag/BugsnagReporter.swift
+++ b/Sources/Bugsnag/BugsnagReporter.swift
@@ -103,15 +103,14 @@ extension BugsnagReporter {
                 eventRequestBody = nil
             }
             
-            var headerDict: [String : Any] = request.headers.reduce([:], { result, value in
-                var copy = result
-                copy[value.0] = value.1
-                return copy
-            })
+            var headerDict: [String : Any] = request.headers.reduce(into: [:]) { result, value in
+                result[value.0] = value.1
+            }
             strip(keys: configuration.keyFilters, from: &headerDict)
 
-            let filteredHeaders: [(String, String)] = headerDict.map {
-                k, v in (k, v as! String)
+            let filteredHeaders: [(String, String)] = headerDict.compactMap { k, v in
+                guard let value = v as? String else { return nil }
+                return (k, value)
             }
             
             eventRequest = .init(

--- a/Sources/Bugsnag/BugsnagReporter.swift
+++ b/Sources/Bugsnag/BugsnagReporter.swift
@@ -102,10 +102,22 @@ extension BugsnagReporter {
             } else {
                 eventRequestBody = nil
             }
+            
+            var headerDict: [String : Any] = request.headers.reduce([:], { result, value in
+                var copy = result
+                copy[value.0] = value.1
+                return copy
+            })
+            strip(keys: configuration.keyFilters, from: &headerDict)
+
+            let filteredHeaders: [(String, String)] = headerDict.map {
+                k, v in (k, v as! String)
+            }
+            
             eventRequest = .init(
                 body: eventRequestBody,
                 clientIp: request.headers.forwarded.first(where: { $0.for != nil })?.for ?? request.remoteAddress?.hostname,
-                headers: .init(uniqueKeysWithValues: request.headers.map { $0 }),
+                headers: .init(uniqueKeysWithValues: filteredHeaders),
                 httpMethod: request.method.string,
                 referer: "n/a",
                 url: request.url.string

--- a/Tests/BugsnagTests/BugsnagTests.swift
+++ b/Tests/BugsnagTests/BugsnagTests.swift
@@ -57,7 +57,7 @@ final class BugsnagTests: XCTestCase {
         app.bugsnag.configuration = .init(
             apiKey: "foo",
             releaseStage: "debug",
-            keyFilters: ["email", "password"]
+            keyFilters: ["email", "password", "Authorization"]
         )
         app.clients.use(.test)
 
@@ -90,7 +90,9 @@ final class BugsnagTests: XCTestCase {
                 application: app,
                 method: .POST,
                 url: "/test",
-                on: app.eventLoopGroup.next()
+                headers: [
+                    "Authorization": "Bearer SupErSecretT0ken!"
+                ], on: app.eventLoopGroup.next()
             )
             try request.content.encode(vapor)
             try request.bugsnag.report(Abort(.internalServerError, reason: "Oops")).wait()
@@ -103,6 +105,7 @@ final class BugsnagTests: XCTestCase {
                 User.self,
                 from: Data(payload.events[0].request!.body!.utf8)
             )
+            let headers = payload.events[0].request!.headers
             XCTAssertEqual(user.name, "Vapor")
             XCTAssertEqual(user.email, "<hidden>")
             XCTAssertEqual(user.password, "<hidden>")
@@ -110,6 +113,7 @@ final class BugsnagTests: XCTestCase {
             XCTAssertEqual(user.user?.email, "<hidden>")
             XCTAssertEqual(user.user?.password, "<hidden>")
             XCTAssertNil(user.user?.user)
+            XCTAssertEqual(headers["Authorization"], "<hidden>")
         }
     }
 


### PR DESCRIPTION
The HTTP headers were not being stripped of sensitive data as the request data was. This PR fixes that.