### PR TITLE
Fix placement hint about BugsnagMiddleware

### DIFF
--- a/Sources/Bugsnag/BugsnagMiddleware.swift
+++ b/Sources/Bugsnag/BugsnagMiddleware.swift
@@ -4,7 +4,7 @@ import Vapor
 ///
 ///     app.middleware.use(BugsnagMiddleware())
 ///
-/// This should be placed _before_ `ErrorMiddleware`. 
+/// This should be placed _after_ `ErrorMiddleware`. 
 public struct BugsnagMiddleware {
     public init() { }
 }


### PR DESCRIPTION
The `BugsnagMiddleware` should be placed _after_ the `ErrorMiddleware` otherwise `ErrorMiddleware` will consume the error, before `BugsnagMiddleware` has a chance to report it.