### PR TITLE
User type, metadata and Request ID

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,16 @@ on:
   pull_request:
   push:
     branches:
-    - master
+      - master
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: swift:5.2-bionic
+    container: swift:5.5-focal
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread
   macOS:
     runs-on: macos-latest
     steps:
@@ -23,4 +23,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
@@ -11,10 +11,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.10.0"),
+        .package(url: "https://github.com/skelpo/JSON", from: "1.1.4"),
     ],
     targets: [
         .target(name: "Bugsnag", dependencies: [
             .product(name: "Vapor", package: "vapor"),
+            .product(name: "JSON", package: "JSON"),
         ]),
         .testTarget(name: "BugsnagTests", dependencies: [
             .target(name: "Bugsnag"),

--- a/Sources/Bugsnag/BugsnagPayload.swift
+++ b/Sources/Bugsnag/BugsnagPayload.swift
@@ -1,4 +1,5 @@
 import Vapor
+import JSON
 
 struct BugsnagPayload: Codable {
     let apiKey: String
@@ -34,14 +35,12 @@ struct BugsnagPayload: Codable {
                 let lineNumber: Int
                 let columnNumber: Int
 
-                let code: [String] = []
-                let inProject = true
+                var code: [String] = []
+                var inProject = true
             }
-
-            let type: String
         }
 
-        let metaData: [String: String]
+        let metaData: JSON
 
         let payloadVersion: String
         let request: Request?
@@ -55,9 +54,8 @@ struct BugsnagPayload: Codable {
             let url: String
         }
 
-
         let severity: String
-        let unhandled = true
+        var unhandled = true
         let user: User?
 
         struct User: Codable {

--- a/Sources/Bugsnag/BugsnagUsers.swift
+++ b/Sources/Bugsnag/BugsnagUsers.swift
@@ -18,13 +18,16 @@ import Vapor
 ///
 /// Only one user can be included in a Bugsnag report.
 public struct BugsnagUsers {
-    var storage: [(Request) -> (CustomStringConvertible?)]
+    var storage: [(Request) -> (type: String, id: CustomStringConvertible)?]
 
     public mutating func add<User>(_ user: User.Type)
         where User: BugsnagUser & Authenticatable
     {
         self.storage.append({ request in
-            request.auth.get(User.self)?.bugsnagID
+            if let userID = request.auth.get(User.self)?.bugsnagID {
+                return (String(describing: user), userID)
+            }
+            return nil
         })
     }
 }


### PR DESCRIPTION
Brings a few extra features to the library:
* Ability to supply custom metadata directly in `bugsnag.report()`.
* Attaches the Request ID to the metadata automatically
* Attaches the User type to the metadata, useful for multiple user types
* Change the "error" field to the actual error class not just always the string "error"

I brought in the JSON library to deal with metadata that is not just a `String`